### PR TITLE
Harmonize gradle plugin version with cwa-app-android

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -23,7 +23,7 @@
 object Versions {
 
     // Base
-    const val gradle = "4.1.3"
+    const val gradle = "4.2.2"
     const val kotlin = "1.4.32"
 
     // Decoder

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -23,7 +23,7 @@
 object Versions {
 
     // Base
-    const val gradle = "4.2.2"
+    const val gradle = "7.0.2"
     const val kotlin = "1.4.32"
 
     // Decoder


### PR DESCRIPTION
Having the same gradle plugin version as the CWA Android project allows building this repository as an [included / composite build](https://docs.gradle.org/6.3/userguide/composite_builds.html#included_build_declaring_substitutions) using this snippet in `settings.gradle`:

```
includeBuild('dgc-certlogic-android') {
    dependencySubstitution {
        substitute module('dgca.verifier.app:dgc-certlogic-android-light') with project(':engine')
    }
}
```

We want to do this to build the application from source without relying on the provided binaries by using a [`git submodule`](https://git-scm.com/book/de/v2/Git-Tools-Submodule). If you like, I can open a CWA PR that builds the certlogic engine from source there as well, as it might save some work when manually refreshing and committing updated maven artifacts.